### PR TITLE
Add AWS profile manager and UI for bucket scanning

### DIFF
--- a/windirstat_s3/MainWindow.xaml
+++ b/windirstat_s3/MainWindow.xaml
@@ -6,7 +6,18 @@
         xmlns:local="clr-namespace:windirstat_s3"
         mc:Ignorable="d"
         Title="MainWindow" Height="450" Width="800">
-    <Grid>
-
+    <Grid Margin="10">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+        <StackPanel Orientation="Horizontal" Margin="0,0,0,10">
+            <TextBlock Text="Perfil:" VerticalAlignment="Center" />
+            <ComboBox x:Name="ProfileComboBox" Width="200" Margin="5,0,0,0" />
+            <TextBlock Text="Bucket:" Margin="20,0,0,0" VerticalAlignment="Center" />
+            <TextBox x:Name="BucketTextBox" Width="200" Margin="5,0,0,0" />
+            <Button Content="Scan" Margin="10,0,0,0" Click="ScanButton_Click" />
+        </StackPanel>
+        <TreeView x:Name="ResultTree" Grid.Row="1" />
     </Grid>
 </Window>

--- a/windirstat_s3/MainWindow.xaml.cs
+++ b/windirstat_s3/MainWindow.xaml.cs
@@ -1,24 +1,43 @@
-﻿using System.Text;
+using System;
 using System.Windows;
-using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
-using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Navigation;
-using System.Windows.Shapes;
+using Amazon;
+using Amazon.S3;
+using windirstat_s3.Services;
 
-namespace windirstat_s3
+namespace windirstat_s3;
+
+public partial class MainWindow : Window
 {
-    /// <summary>
-    /// Interaction logic for MainWindow.xaml
-    /// </summary>
-    public partial class MainWindow : Window
+    private readonly AwsProfileManager _profileManager = new();
+
+    public MainWindow()
     {
-        public MainWindow()
+        InitializeComponent();
+        ProfileComboBox.ItemsSource = _profileManager.ListProfiles();
+    }
+
+    private async void ScanButton_Click(object sender, RoutedEventArgs e)
+    {
+        var profileName = ProfileComboBox.SelectedItem as string;
+        var bucketName = BucketTextBox.Text;
+
+        if (string.IsNullOrWhiteSpace(profileName) || string.IsNullOrWhiteSpace(bucketName))
         {
-            InitializeComponent();
+            MessageBox.Show("Selecione um perfil e informe o nome do bucket.");
+            return;
+        }
+
+        try
+        {
+            var credentials = _profileManager.GetCredentials(profileName);
+            using var client = new AmazonS3Client(credentials, RegionEndpoint.USEast1);
+            var scanner = new S3Scanner(client);
+            var result = await scanner.ScanAsync(bucketName);
+            MessageBox.Show($"Total bytes: {result.Size}");
+        }
+        catch (Exception ex)
+        {
+            MessageBox.Show(ex.Message, "Erro", MessageBoxButton.OK, MessageBoxImage.Error);
         }
     }
 }

--- a/windirstat_s3/Services/AwsProfileManager.cs
+++ b/windirstat_s3/Services/AwsProfileManager.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Amazon.Runtime;
+using Amazon.Runtime.CredentialManagement;
+
+namespace windirstat_s3.Services;
+
+public class AwsProfileManager
+{
+    private readonly SharedCredentialsFile _sharedFile;
+
+    public AwsProfileManager()
+    {
+        var path = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+            ".aws",
+            "credentials");
+        _sharedFile = new SharedCredentialsFile(path);
+    }
+
+    public IEnumerable<string> ListProfiles()
+    {
+        return _sharedFile.ListProfiles().Select(p => p.Name);
+    }
+
+    public AWSCredentials GetCredentials(string profileName)
+    {
+        if (_sharedFile.TryGetProfile(profileName, out var profile) &&
+            AWSCredentialsFactory.TryGetAWSCredentials(profile, _sharedFile, out var credentials))
+        {
+            return credentials;
+        }
+
+        throw new InvalidOperationException($"Profile '{profileName}' not found.");
+    }
+}


### PR DESCRIPTION
## Summary
- add AwsProfileManager for reading profiles from `~/.aws/credentials`
- extend MainWindow UI to choose AWS profile and bucket before scanning
- use selected profile when constructing AmazonS3Client

## Testing
- `dotnet build windirstat_s3/windirstat_s3.csproj -p:EnableWindowsTargeting=true` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets missing)*

------
https://chatgpt.com/codex/tasks/task_b_689373af080c8327b9e1e3924b321b4f