### PR TITLE
Handle nullable S3 object size

### DIFF
--- a/windirstat_s3/Services/S3Scanner.cs
+++ b/windirstat_s3/Services/S3Scanner.cs
@@ -45,7 +45,7 @@ public class S3Scanner
                     continue;
                 }
 
-                AddObject(root, s3Object.Key, s3Object.Size);
+                AddObject(root, s3Object.Key, s3Object.Size.GetValueOrDefault());
             }
 
             request.ContinuationToken = response.NextContinuationToken;


### PR DESCRIPTION
## Summary
- Avoid nullable long conversion errors when adding S3 objects

## Testing
- `dotnet build windirstat_s3/windirstat_s3.csproj` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_b_689377bf91b483279018a99d80b52712