### PR TITLE
Add extension summary view and filtering for S3 scan

### DIFF
--- a/windirstat_s3/MainWindow.xaml
+++ b/windirstat_s3/MainWindow.xaml
@@ -31,11 +31,31 @@
                     </HierarchicalDataTemplate>
                 </TreeView.ItemTemplate>
             </TreeView>
-            <dv:TreeMap x:Name="ResultTreemap" Grid.Column="1">
-                <dv:TreeMap.ItemDefinition>
-                    <dv:TreeMapItemDefinition ValueBinding="{Binding Size}" LabelBinding="{Binding Name}" />
-                </dv:TreeMap.ItemDefinition>
-            </dv:TreeMap>
+            <TabControl Grid.Column="1">
+                <TabItem Header="Treemap">
+                    <dv:TreeMap x:Name="ResultTreemap">
+                        <dv:TreeMap.ItemDefinition>
+                            <dv:TreeMapItemDefinition ValueBinding="{Binding Size}" LabelBinding="{Binding Name}" />
+                        </dv:TreeMap.ItemDefinition>
+                    </dv:TreeMap>
+                </TabItem>
+                <TabItem Header="Extensões">
+                    <Grid Margin="5">
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="*" />
+                        </Grid.RowDefinitions>
+                        <TextBox x:Name="ExtensionFilterTextBox" Margin="0,0,0,5" TextChanged="ExtensionFilterTextBox_TextChanged" />
+                        <DataGrid x:Name="ExtensionDataGrid" Grid.Row="1" AutoGenerateColumns="False" IsReadOnly="True">
+                            <DataGrid.Columns>
+                                <DataGridTextColumn Header="Extensão" Binding="{Binding Extension}" />
+                                <DataGridTextColumn Header="Quantidade" Binding="{Binding Count}" />
+                                <DataGridTextColumn Header="Tamanho Total" Binding="{Binding Size}" />
+                            </DataGrid.Columns>
+                        </DataGrid>
+                    </Grid>
+                </TabItem>
+            </TabControl>
         </Grid>
     </Grid>
 </Window>

--- a/windirstat_s3/Services/ExtensionInfo.cs
+++ b/windirstat_s3/Services/ExtensionInfo.cs
@@ -1,0 +1,8 @@
+namespace windirstat_s3.Services;
+
+public class ExtensionInfo
+{
+    public long Count { get; set; }
+    public long Size { get; set; }
+}
+

--- a/windirstat_s3/ViewModels/DirectoryNodeViewModel.cs
+++ b/windirstat_s3/ViewModels/DirectoryNodeViewModel.cs
@@ -9,6 +9,7 @@ public class DirectoryNodeViewModel
     public string Name { get; }
     public long Size { get; }
     public ObservableCollection<DirectoryNodeViewModel> Children { get; } = new();
+    public ObservableCollection<ExtensionInfoViewModel> Extensions { get; } = new();
 
     public string Display => $"{Name} ({Size})";
 
@@ -19,6 +20,10 @@ public class DirectoryNodeViewModel
         foreach (var child in node.Children.Values.OrderByDescending(c => c.Size))
         {
             Children.Add(new DirectoryNodeViewModel(child));
+        }
+        foreach (var ext in node.Extensions.OrderByDescending(e => e.Value.Size))
+        {
+            Extensions.Add(new ExtensionInfoViewModel(ext.Key, ext.Value));
         }
     }
 }

--- a/windirstat_s3/ViewModels/ExtensionInfoViewModel.cs
+++ b/windirstat_s3/ViewModels/ExtensionInfoViewModel.cs
@@ -1,0 +1,18 @@
+using windirstat_s3.Services;
+
+namespace windirstat_s3.ViewModels;
+
+public class ExtensionInfoViewModel
+{
+    public string Extension { get; }
+    public long Count { get; }
+    public long Size { get; }
+
+    public ExtensionInfoViewModel(string extension, ExtensionInfo info)
+    {
+        Extension = string.IsNullOrEmpty(extension) ? "(sem extensão)" : extension;
+        Count = info.Count;
+        Size = info.Size;
+    }
+}
+


### PR DESCRIPTION
## Summary
- track file extension counts and sizes while scanning S3
- show sortable extension summary and filter in a new tab of the main window

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_b_68937b8ed99883279ffff23966eba357