### PR TITLE
feat: replace DataVisualization toolkit with LiveCharts

### DIFF
--- a/windirstat_s3/MainWindow.xaml
+++ b/windirstat_s3/MainWindow.xaml
@@ -4,7 +4,7 @@
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:windirstat_s3"
-        xmlns:dv="clr-namespace:System.Windows.Controls;assembly=System.Windows.Controls.DataVisualization.Toolkit"
+        xmlns:lvc="clr-namespace:LiveChartsCore.SkiaSharpView.WPF;assembly=LiveChartsCore.SkiaSharpView.WPF"
         mc:Ignorable="d"
         Title="MainWindow" Height="450" Width="800">
     <Grid Margin="10">
@@ -31,11 +31,7 @@
                     </HierarchicalDataTemplate>
                 </TreeView.ItemTemplate>
             </TreeView>
-            <dv:TreeMap x:Name="ResultTreemap" Grid.Column="1">
-                <dv:TreeMap.ItemDefinition>
-                    <dv:TreeMapItemDefinition ValueBinding="{Binding Size}" LabelBinding="{Binding Name}" />
-                </dv:TreeMap.ItemDefinition>
-            </dv:TreeMap>
+            <lvc:PieChart x:Name="ResultChart" Grid.Column="1" />
         </Grid>
     </Grid>
 </Window>

--- a/windirstat_s3/MainWindow.xaml.cs
+++ b/windirstat_s3/MainWindow.xaml.cs
@@ -1,7 +1,11 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Windows;
 using Amazon;
 using Amazon.S3;
+using LiveChartsCore;
+using LiveChartsCore.SkiaSharpView;
 using windirstat_s3.Services;
 using windirstat_s3.ViewModels;
 
@@ -37,7 +41,7 @@ public partial class MainWindow : Window
             var result = await scanner.ScanAsync(bucketName);
             _root = new DirectoryNodeViewModel(result);
             ResultTree.ItemsSource = _root.Children;
-            ResultTreemap.ItemsSource = null;
+            UpdateChart(Array.Empty<DirectoryNodeViewModel>());
         }
         catch (Exception ex)
         {
@@ -49,7 +53,19 @@ public partial class MainWindow : Window
     {
         if (ResultTree.SelectedItem is DirectoryNodeViewModel node)
         {
-            ResultTreemap.ItemsSource = node.Children;
+            UpdateChart(node.Children);
         }
+    }
+
+    private void UpdateChart(IEnumerable<DirectoryNodeViewModel> nodes)
+    {
+        ResultChart.Series = nodes
+            .Select(n => new PieSeries<double>
+            {
+                Values = new[] { (double)n.Size },
+                Name = n.Name
+            })
+            .Cast<ISeries>()
+            .ToArray();
     }
 }

--- a/windirstat_s3/windirstat_s3.csproj
+++ b/windirstat_s3/windirstat_s3.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="AWSSDK.S3" Version="4.0.6.3" />
-    <PackageReference Include="System.Windows.Controls.DataVisualization.Toolkit" Version="3.5.50211.1" />
+    <PackageReference Include="LiveChartsCore.SkiaSharpView.WPF" Version="2.0.0-beta.3" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- switch from System.Windows.Controls.DataVisualization toolkit to LiveChartsCore.SkiaSharpView
- visualize directory sizes with a LiveCharts pie chart

## Testing
- `dotnet restore windirstat_s3/windirstat_s3.csproj`
- `dotnet build windirstat_s3/windirstat_s3.csproj -c Release` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_b_68937b4ed39883279a5f7a676c96bfdb