### PR TITLE
Replace deprecated DataVisualization toolkit with modern port

### DIFF
--- a/windirstat_s3/MainWindow.xaml
+++ b/windirstat_s3/MainWindow.xaml
@@ -4,7 +4,7 @@
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:windirstat_s3"
-        xmlns:dv="clr-namespace:System.Windows.Controls;assembly=System.Windows.Controls.DataVisualization.Toolkit"
+        xmlns:dv="clr-namespace:System.Windows.Controls;assembly=DotNetProjects.DataVisualization.Toolkit"
         mc:Ignorable="d"
         Title="MainWindow" Height="450" Width="800">
     <Grid Margin="10">

--- a/windirstat_s3/windirstat_s3.csproj
+++ b/windirstat_s3/windirstat_s3.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="AWSSDK.S3" Version="4.0.6.3" />
-    <PackageReference Include="System.Windows.Controls.DataVisualization.Toolkit" Version="3.5.50211.1" />
+    <PackageReference Include="DotNetProjects.WpfToolkit.DataVisualization" Version="6.1.94" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- swap System.Windows.Controls.DataVisualization.Toolkit for DotNetProjects.WpfToolkit.DataVisualization
- adjust XAML namespace to reference new assembly

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets missing)*

------
https://chatgpt.com/codex/tasks/task_b_689399d1e3788327b80f6041b661b940