### PR TITLE
Fix TreeMap namespace reference for DotNetProjects toolkit

### DIFF
--- a/windirstat_s3/MainWindow.xaml
+++ b/windirstat_s3/MainWindow.xaml
@@ -4,7 +4,7 @@
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:windirstat_s3"
-        xmlns:dv="clr-namespace:System.Windows.Controls;assembly=DotNetProjects.DataVisualization.Toolkit"
+        xmlns:dv="clr-namespace:System.Windows.Controls.DataVisualization;assembly=DotNetProjects.DataVisualization.Toolkit"
         mc:Ignorable="d"
         Title="MainWindow" Height="450" Width="800">
     <Grid Margin="10">


### PR DESCRIPTION
## Summary
- correct TreeMap namespace to match DotNetProjects DataVisualization Toolkit

## Testing
- `dotnet build windirstat_s3/windirstat_s3.csproj` *(fails: The imported project "/usr/lib/dotnet/sdk/8.0.118/Sdks/Microsoft.NET.Sdk.WindowsDesktop/targets/Microsoft.NET.Sdk.WindowsDesktop.targets" was not found)*

------
https://chatgpt.com/codex/tasks/task_b_6893ab79f5b08327b29b21216e2b94c4