### PR TITLE
Use item template for TreeMap labels

### DIFF
--- a/windirstat_s3/MainWindow.xaml
+++ b/windirstat_s3/MainWindow.xaml
@@ -35,7 +35,13 @@
                 <TabItem Header="Treemap">
                     <dv:TreeMap x:Name="ResultTreemap">
                         <dv:TreeMap.ItemDefinition>
-                            <dv:TreeMapItemDefinition ValueBinding="{Binding Size}" LabelBinding="{Binding Name}" />
+                            <dv:TreeMapItemDefinition ValueBinding="{Binding Size}" ItemsSource="{Binding Children}">
+                                <dv:TreeMapItemDefinition.ItemTemplate>
+                                    <DataTemplate>
+                                        <TextBlock Text="{Binding Name}" />
+                                    </DataTemplate>
+                                </dv:TreeMapItemDefinition.ItemTemplate>
+                            </dv:TreeMapItemDefinition>
                         </dv:TreeMap.ItemDefinition>
                     </dv:TreeMap>
                 </TabItem>


### PR DESCRIPTION
## Summary
- replace invalid TreeMap `LabelBinding` with an item template that binds to `Name`
- bind `TreeMapItemDefinition` to child nodes for hierarchy

## Testing
- `dotnet build windirstat_s3/windirstat_s3.sln` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_b_6893b157009883278de9c8348cbeeee1