### PR TITLE
Fix nullable IsTruncated handling

### DIFF
--- a/windirstat_s3/Services/S3Scanner.cs
+++ b/windirstat_s3/Services/S3Scanner.cs
@@ -52,7 +52,7 @@ public class S3Scanner
 
             request.ContinuationToken = response.NextContinuationToken;
 
-        } while (response.IsTruncated);
+        } while (response.IsTruncated.GetValueOrDefault());
 
         return root;
     }


### PR DESCRIPTION
## Summary
- use `GetValueOrDefault()` when checking `ListObjectsV2Response.IsTruncated`

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets not found)*

------
https://chatgpt.com/codex/tasks/task_b_6893b355f18483278ff9f1db96c6b53e