### PR TITLE
Prompt for AWS credentials when none configured

### DIFF
--- a/windirstat_s3/CredentialsWindow.xaml
+++ b/windirstat_s3/CredentialsWindow.xaml
@@ -1,0 +1,18 @@
+<Window x:Class="windirstat_s3.CredentialsWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Configurar acesso" SizeToContent="WidthAndHeight" WindowStartupLocation="CenterOwner">
+    <StackPanel Margin="10">
+        <TextBlock Text="Access Key" />
+        <TextBox x:Name="AccessKeyTextBox" Width="250" Margin="0,5,0,10" />
+        <TextBlock Text="Secret Key" />
+        <PasswordBox x:Name="SecretKeyBox" Width="250" Margin="0,5,0,10" />
+        <TextBlock Text="Região" />
+        <ComboBox x:Name="RegionComboBox" Width="250" Margin="0,5,0,10" />
+        <CheckBox x:Name="SaveCheckBox" Content="Salvar credenciais" IsChecked="True" Margin="0,0,0,10" />
+        <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
+            <Button Content="OK" Width="75" Margin="0,0,5,0" IsDefault="True" Click="OkButton_Click" />
+            <Button Content="Cancelar" Width="75" IsCancel="True" />
+        </StackPanel>
+    </StackPanel>
+</Window>

--- a/windirstat_s3/CredentialsWindow.xaml.cs
+++ b/windirstat_s3/CredentialsWindow.xaml.cs
@@ -1,0 +1,29 @@
+using System.Windows;
+using Amazon;
+
+namespace windirstat_s3;
+
+public partial class CredentialsWindow : Window
+{
+    public CredentialsWindow()
+    {
+        InitializeComponent();
+        RegionComboBox.ItemsSource = RegionEndpoint.EnumerableAllRegions;
+        RegionComboBox.SelectedItem = RegionEndpoint.USEast1;
+    }
+
+    public string AccessKeyId => AccessKeyTextBox.Text;
+    public string SecretAccessKey => SecretKeyBox.Password;
+    public RegionEndpoint? SelectedRegion => RegionComboBox.SelectedItem as RegionEndpoint;
+    public bool SaveCredentials => SaveCheckBox.IsChecked == true;
+
+    private void OkButton_Click(object sender, RoutedEventArgs e)
+    {
+        if (string.IsNullOrWhiteSpace(AccessKeyId) || string.IsNullOrWhiteSpace(SecretAccessKey) || SelectedRegion == null)
+        {
+            MessageBox.Show("Informe a chave, segredo e região.");
+            return;
+        }
+        DialogResult = true;
+    }
+}

--- a/windirstat_s3/Services/AwsProfileManager.cs
+++ b/windirstat_s3/Services/AwsProfileManager.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using Amazon;
 using Amazon.Runtime;
 using Amazon.Runtime.CredentialManagement;
 
@@ -34,5 +35,31 @@ public class AwsProfileManager
         }
 
         throw new InvalidOperationException($"Profile '{profileName}' not found.");
+    }
+
+    public RegionEndpoint GetRegion(string profileName)
+    {
+        if (_sharedFile.TryGetProfile(profileName, out var profile) && profile.Region != null)
+        {
+            return profile.Region;
+        }
+
+        throw new InvalidOperationException($"Profile '{profileName}' not found or has no region.");
+    }
+
+    public void SaveProfile(string profileName, string accessKey, string secretKey, RegionEndpoint region)
+    {
+        var options = new CredentialProfileOptions
+        {
+            AccessKey = accessKey,
+            SecretKey = secretKey
+        };
+
+        var profile = new CredentialProfile(profileName, options)
+        {
+            Region = region
+        };
+
+        _sharedFile.RegisterProfile(profile);
     }
 }


### PR DESCRIPTION
## Summary
- prompt for AWS keys and region when no profiles exist and allow saving them
- load region from saved profile when scanning S3

## Testing
- `dotnet build s3_config_cli/s3_config_cli.csproj`
- `dotnet build windirstat_s3/windirstat_s3.csproj` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_b_6893bc0992f483278f971973027dd566