### PR TITLE
Restructure layout to mimic WinDirStat

### DIFF
--- a/windirstat_s3/MainWindow.xaml
+++ b/windirstat_s3/MainWindow.xaml
@@ -26,48 +26,49 @@
               <Button Content="Export JSON" Margin="5,0,0,0" Click="ExportJsonButton_Click" />
           </StackPanel>
         <Grid Grid.Row="1">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="2*" />
+                <RowDefinition Height="3*" />
+            </Grid.RowDefinitions>
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="2*" />
                 <ColumnDefinition Width="3*" />
             </Grid.ColumnDefinitions>
-            <TreeView x:Name="ResultTree" SelectedItemChanged="ResultTree_SelectedItemChanged">
+
+            <TreeView x:Name="ResultTree" SelectedItemChanged="ResultTree_SelectedItemChanged" Grid.Row="0" Grid.Column="0">
                 <TreeView.ItemTemplate>
                     <HierarchicalDataTemplate ItemsSource="{Binding Children}">
                         <TextBlock Text="{Binding Display}" />
                     </HierarchicalDataTemplate>
                 </TreeView.ItemTemplate>
             </TreeView>
-            <TabControl Grid.Column="1">
-                <TabItem Header="Treemap">
-                    <dv:TreeMap x:Name="ResultTreemap">
-                        <dv:TreeMap.ItemDefinition>
-                            <dv:TreeMapItemDefinition ValueBinding="{Binding Size}" ItemsSource="{Binding Children}">
-                                <dv:TreeMapItemDefinition.ItemTemplate>
-                                    <DataTemplate>
-                                        <TextBlock Text="{Binding Name}" />
-                                    </DataTemplate>
-                                </dv:TreeMapItemDefinition.ItemTemplate>
-                            </dv:TreeMapItemDefinition>
-                        </dv:TreeMap.ItemDefinition>
-                    </dv:TreeMap>
-                </TabItem>
-                <TabItem Header="Extensões">
-                    <Grid Margin="5">
-                        <Grid.RowDefinitions>
-                            <RowDefinition Height="Auto" />
-                            <RowDefinition Height="*" />
-                        </Grid.RowDefinitions>
-                        <TextBox x:Name="ExtensionFilterTextBox" Margin="0,0,0,5" TextChanged="ExtensionFilterTextBox_TextChanged" />
-                        <DataGrid x:Name="ExtensionDataGrid" Grid.Row="1" AutoGenerateColumns="False" IsReadOnly="True">
-                            <DataGrid.Columns>
-                                <DataGridTextColumn Header="Extensão" Binding="{Binding Extension}" />
-                                <DataGridTextColumn Header="Quantidade" Binding="{Binding Count}" />
-                                <DataGridTextColumn Header="Tamanho Total" Binding="{Binding Size}" />
-                            </DataGrid.Columns>
-                        </DataGrid>
-                    </Grid>
-                </TabItem>
-            </TabControl>
+
+            <Grid Grid.Row="0" Grid.Column="1" Margin="5">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="*" />
+                </Grid.RowDefinitions>
+                <TextBox x:Name="ExtensionFilterTextBox" Margin="0,0,0,5" TextChanged="ExtensionFilterTextBox_TextChanged" />
+                <DataGrid x:Name="ExtensionDataGrid" Grid.Row="1" AutoGenerateColumns="False" IsReadOnly="True">
+                    <DataGrid.Columns>
+                        <DataGridTextColumn Header="Extensão" Binding="{Binding Extension}" />
+                        <DataGridTextColumn Header="Quantidade" Binding="{Binding Count}" />
+                        <DataGridTextColumn Header="Tamanho Total" Binding="{Binding Size}" />
+                    </DataGrid.Columns>
+                </DataGrid>
+            </Grid>
+
+            <dv:TreeMap x:Name="ResultTreemap" Grid.Row="1" Grid.ColumnSpan="2">
+                <dv:TreeMap.ItemDefinition>
+                    <dv:TreeMapItemDefinition ValueBinding="{Binding Size}" ItemsSource="{Binding Children}">
+                        <dv:TreeMapItemDefinition.ItemTemplate>
+                            <DataTemplate>
+                                <TextBlock Text="{Binding Name}" />
+                            </DataTemplate>
+                        </dv:TreeMapItemDefinition.ItemTemplate>
+                    </dv:TreeMapItemDefinition>
+                </dv:TreeMap.ItemDefinition>
+            </dv:TreeMap>
         </Grid>
     </Grid>
 </Window>

--- a/windirstat_s3/Services/S3Scanner.cs
+++ b/windirstat_s3/Services/S3Scanner.cs
@@ -8,6 +8,7 @@ public class FolderNode
 {
     public string Name { get; }
     public long Size { get; set; }
+    public long FileCount { get; set; }
     public Dictionary<string, FolderNode> Children { get; } = new();
     public Dictionary<string, ExtensionInfo> Extensions { get; } = new();
 
@@ -109,6 +110,7 @@ public class S3Scanner
     private static void AddObject(FolderNode root, string key, long size)
     {
         root.Size += size;
+        root.FileCount++;
         var node = root;
 
         var extension = Path.GetExtension(key).ToLowerInvariant();
@@ -125,6 +127,7 @@ public class S3Scanner
             }
 
             child.Size += size;
+            child.FileCount++;
             node = child;
 
             UpdateExtension(node, extension, size);

--- a/windirstat_s3/ViewModels/DirectoryNodeViewModel.cs
+++ b/windirstat_s3/ViewModels/DirectoryNodeViewModel.cs
@@ -8,15 +8,17 @@ public class DirectoryNodeViewModel
 {
     public string Name { get; }
     public long Size { get; }
+    public long FileCount { get; }
     public ObservableCollection<DirectoryNodeViewModel> Children { get; } = new();
     public ObservableCollection<ExtensionInfoViewModel> Extensions { get; } = new();
 
-    public string Display => $"{Name} ({Size})";
+    public string Display => $"{Name} ({FileCount} arquivos, {Size} bytes)";
 
     public DirectoryNodeViewModel(FolderNode node)
     {
         Name = node.Name;
         Size = node.Size;
+        FileCount = node.FileCount;
         foreach (var child in node.Children.Values.OrderByDescending(c => c.Size))
         {
             Children.Add(new DirectoryNodeViewModel(child));


### PR DESCRIPTION
## Summary
- show file counts alongside sizes in directory tree
- rearrange main window to split tree, extension list, and treemap

## Testing
- `dotnet build windirstat_s3/windirstat_s3.csproj` *(fails: MSB4019: The imported project ...Microsoft.NET.Sdk.WindowsDesktop.targets was not found)*

------
https://chatgpt.com/codex/tasks/task_b_6893c5262f04832794aa8fcb1202c56b