### PR TITLE
Fix DirectoryNodeViewModel namespace in XAML

### DIFF
--- a/windirstat_s3/MainWindow.xaml
+++ b/windirstat_s3/MainWindow.xaml
@@ -1,10 +1,10 @@
 <Window x:Class="windirstat_s3.MainWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:local="clr-namespace:windirstat_s3"
+        xmlns:viewModels="clr-namespace:windirstat_s3.ViewModels"
         Title="WinDirStat S3" Height="600" Width="900">
     <Window.Resources>
-        <HierarchicalDataTemplate DataType="{x:Type local:DirectoryNodeViewModel}" ItemsSource="{Binding Children}">
+        <HierarchicalDataTemplate DataType="{x:Type viewModels:DirectoryNodeViewModel}" ItemsSource="{Binding Children}">
             <StackPanel Orientation="Horizontal">
                 <TextBlock Text="{Binding Name}"/>
             </StackPanel>


### PR DESCRIPTION
## Summary
- reference DirectoryNodeViewModel from the ViewModels namespace

## Testing
- `dotnet build windirstat_s3/windirstat_s3.sln` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets not found)*

------
https://chatgpt.com/codex/tasks/task_b_68949d7918e88327a549852850463983