### PR TITLE
feat: add Windirstat.Core library

### DIFF
--- a/Windirstat.Core/Models/ExtensionInfo.cs
+++ b/Windirstat.Core/Models/ExtensionInfo.cs
@@ -1,4 +1,4 @@
-namespace windirstat_s3.Services;
+namespace Windirstat.Core.Models;
 
 public class ExtensionInfo
 {

--- a/Windirstat.Core/Models/FileStat.cs
+++ b/Windirstat.Core/Models/FileStat.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace Windirstat.Core.Models;
+
+public class FileStat
+{
+    public string Path { get; set; } = string.Empty;
+    public long Size { get; set; }
+    public DateTime LastModified { get; set; }
+}

--- a/Windirstat.Core/Models/FolderNode.cs
+++ b/Windirstat.Core/Models/FolderNode.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Collections.Generic;
+
+namespace Windirstat.Core.Models;
+
+public class FolderNode
+{
+    public string Name { get; }
+    public long Size { get; set; }
+    public long FileCount { get; set; }
+    public long OwnSize { get; set; }
+    public DateTime LastModified { get; set; }
+    public Dictionary<string, FolderNode> Children { get; } = new();
+    public Dictionary<string, ExtensionInfo> Extensions { get; } = new();
+
+    public FolderNode(string name)
+    {
+        Name = name;
+    }
+}

--- a/Windirstat.Core/ReportExporter.cs
+++ b/Windirstat.Core/ReportExporter.cs
@@ -1,7 +1,8 @@
-using System.Text.Json;
 using System.IO;
+using System.Text.Json;
+using Windirstat.Core.Models;
 
-namespace windirstat_s3.Services;
+namespace Windirstat.Core;
 
 public static class ReportExporter
 {

--- a/Windirstat.Core/S3Scanner.cs
+++ b/Windirstat.Core/S3Scanner.cs
@@ -1,25 +1,14 @@
 using Amazon.S3;
 using Amazon.S3.Model;
 using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Windirstat.Core.Models;
 
-namespace windirstat_s3.Services;
-
-public class FolderNode
-{
-    public string Name { get; }
-    public long Size { get; set; }
-    public long FileCount { get; set; }
-    public long OwnSize { get; set; }
-    public DateTime LastModified { get; set; }
-    public Dictionary<string, FolderNode> Children { get; } = new();
-    public Dictionary<string, ExtensionInfo> Extensions { get; } = new();
-
-    public FolderNode(string name)
-    {
-        Name = name;
-    }
-}
+namespace Windirstat.Core;
 
 public class S3Scanner
 {

--- a/Windirstat.Core/Windirstat.Core.csproj
+++ b/Windirstat.Core/Windirstat.Core.csproj
@@ -1,0 +1,13 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="AWSSDK.S3" Version="4.0.6.3" />
+  </ItemGroup>
+
+</Project>

--- a/s3_config_cli/s3_config_cli.csproj
+++ b/s3_config_cli/s3_config_cli.csproj
@@ -5,4 +5,8 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\\Windirstat.Core\\Windirstat.Core.csproj" />
+  </ItemGroup>
 </Project>

--- a/windirstat_s3/MainWindow.xaml.cs
+++ b/windirstat_s3/MainWindow.xaml.cs
@@ -11,6 +11,8 @@ using Amazon.S3;
 using Microsoft.Win32;
 using windirstat_s3.Services;
 using windirstat_s3.ViewModels;
+using Windirstat.Core;
+using Windirstat.Core.Models;
 
 namespace windirstat_s3;
 

--- a/windirstat_s3/ViewModels/DirectoryNodeViewModel.cs
+++ b/windirstat_s3/ViewModels/DirectoryNodeViewModel.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Collections.ObjectModel;
 using System.Linq;
-using windirstat_s3.Services;
+using Windirstat.Core.Models;
 
 namespace windirstat_s3.ViewModels;
 

--- a/windirstat_s3/windirstat_s3.csproj
+++ b/windirstat_s3/windirstat_s3.csproj
@@ -12,4 +12,8 @@
     <PackageReference Include="AWSSDK.S3" Version="4.0.6.3" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\\Windirstat.Core\\Windirstat.Core.csproj" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
## Summary
- extract S3 scanning and reporting into new Windirstat.Core class library
- reference core library from WPF and CLI projects
- update WPF code to use shared models

## Testing
- `dotnet build Windirstat.Core/Windirstat.Core.csproj`
- `dotnet build windirstat_s3/windirstat_s3.csproj` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*
- `dotnet build s3_config_cli/s3_config_cli.csproj`


------
https://chatgpt.com/codex/tasks/task_b_6894a40941f08327ab4ff34a90604070