### PR TITLE
Integrate tree view and data grid into single tree list view

### DIFF
--- a/windirstat_s3/MainWindow.xaml
+++ b/windirstat_s3/MainWindow.xaml
@@ -3,14 +3,6 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:viewModels="clr-namespace:windirstat_s3.ViewModels"
         Title="WinDirStat S3" Height="600" Width="900">
-    <Window.Resources>
-        <HierarchicalDataTemplate DataType="{x:Type viewModels:DirectoryNodeViewModel}" ItemsSource="{Binding Children}">
-            <StackPanel Orientation="Horizontal">
-                <TextBlock Text="{Binding Name}"/>
-            </StackPanel>
-        </HierarchicalDataTemplate>
-    </Window.Resources>
-
     <Grid Margin="10">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
@@ -32,36 +24,70 @@
             <Button Content="Export JSON" Margin="5,0,0,0" Click="ExportJsonButton_Click"/>
         </StackPanel>
 
-        <Grid Grid.Row="1">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="260"/>
-                <ColumnDefinition Width="*"/>
-            </Grid.ColumnDefinitions>
+        <Grid Grid.Row="1" Grid.IsSharedSizeScope="True">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="*"/>
+            </Grid.RowDefinitions>
 
-            <TreeView x:Name="ResultTree" Grid.Column="0"
-                      ItemsSource="{Binding RootNodes}"
-                      SelectedItemChanged="ResultTree_SelectedItemChanged"/>
+            <Grid Grid.Row="0" Margin="19,0,0,0">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="100" SharedSizeGroup="colProgress"/>
+                    <ColumnDefinition Width="200" SharedSizeGroup="colName"/>
+                    <ColumnDefinition Width="100" SharedSizeGroup="colSubtree"/>
+                    <ColumnDefinition Width="100" SharedSizeGroup="colPercent"/>
+                    <ColumnDefinition Width="80" SharedSizeGroup="colSize"/>
+                    <ColumnDefinition Width="80" SharedSizeGroup="colItems"/>
+                    <ColumnDefinition Width="80" SharedSizeGroup="colFiles"/>
+                    <ColumnDefinition Width="80" SharedSizeGroup="colSubdirs"/>
+                    <ColumnDefinition Width="150" SharedSizeGroup="colLastChanged"/>
+                    <ColumnDefinition Width="100" SharedSizeGroup="colAttributes"/>
+                </Grid.ColumnDefinitions>
+                <TextBlock Grid.Column="0" Text="% Parent"/>
+                <TextBlock Grid.Column="1" Text="Name"/>
+                <TextBlock Grid.Column="2" Text="Subtree Percent"/>
+                <TextBlock Grid.Column="3" Text="Percent"/>
+                <TextBlock Grid.Column="4" Text="Size"/>
+                <TextBlock Grid.Column="5" Text="Items"/>
+                <TextBlock Grid.Column="6" Text="Files"/>
+                <TextBlock Grid.Column="7" Text="Subdirs"/>
+                <TextBlock Grid.Column="8" Text="Last Change"/>
+                <TextBlock Grid.Column="9" Text="Attributes"/>
+            </Grid>
 
-            <DataGrid Grid.Column="1" ItemsSource="{Binding SelectedNodeChildren}"
-                      AutoGenerateColumns="False" IsReadOnly="True">
-                <DataGrid.Columns>
-                    <DataGridTemplateColumn Header="Name" Width="200">
-                        <DataGridTemplateColumn.CellTemplate>
-                            <DataTemplate>
+            <TreeView x:Name="ResultTree" Grid.Row="1" ItemsSource="{Binding RootNodes}">
+                <TreeView.Resources>
+                    <HierarchicalDataTemplate DataType="{x:Type viewModels:DirectoryNodeViewModel}" ItemsSource="{Binding Children}">
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="100" SharedSizeGroup="colProgress"/>
+                                <ColumnDefinition Width="200" SharedSizeGroup="colName"/>
+                                <ColumnDefinition Width="100" SharedSizeGroup="colSubtree"/>
+                                <ColumnDefinition Width="100" SharedSizeGroup="colPercent"/>
+                                <ColumnDefinition Width="80" SharedSizeGroup="colSize"/>
+                                <ColumnDefinition Width="80" SharedSizeGroup="colItems"/>
+                                <ColumnDefinition Width="80" SharedSizeGroup="colFiles"/>
+                                <ColumnDefinition Width="80" SharedSizeGroup="colSubdirs"/>
+                                <ColumnDefinition Width="150" SharedSizeGroup="colLastChanged"/>
+                                <ColumnDefinition Width="100" SharedSizeGroup="colAttributes"/>
+                            </Grid.ColumnDefinitions>
+                            <ProgressBar Grid.Column="0" Minimum="0" Maximum="1" Value="{Binding PercentOfParent}" Margin="0,2,0,2"/>
+                            <StackPanel Grid.Column="1" Orientation="Horizontal">
+                                <TextBlock FontFamily="Segoe MDL2 Assets" Text="{Binding IconGlyph}" Margin="0,0,4,0"/>
                                 <TextBlock Text="{Binding Name}"/>
-                            </DataTemplate>
-                        </DataGridTemplateColumn.CellTemplate>
-                    </DataGridTemplateColumn>
-                    <DataGridTextColumn Header="Subtree Percent" Binding="{Binding SubtreePercent, StringFormat={}{0:P2}}"/>
-                    <DataGridTextColumn Header="Percent" Binding="{Binding PercentOfTotal, StringFormat={}{0:P2}}"/>
-                    <DataGridTextColumn Header="Size" Binding="{Binding Size}"/>
-                    <DataGridTextColumn Header="Items" Binding="{Binding TotalItems}"/>
-                    <DataGridTextColumn Header="Files" Binding="{Binding TotalFiles}"/>
-                    <DataGridTextColumn Header="Subdirs" Binding="{Binding TotalSubdirs}"/>
-                    <DataGridTextColumn Header="Last Change" Binding="{Binding LastModified, StringFormat={}{0:G}}"/>
-                    <DataGridTextColumn Header="Attributes" Binding="{Binding Attributes}"/>
-                </DataGrid.Columns>
-            </DataGrid>
+                            </StackPanel>
+                            <TextBlock Grid.Column="2" Text="{Binding SubtreePercent, StringFormat={}{0:P2}}"/>
+                            <TextBlock Grid.Column="3" Text="{Binding PercentOfTotal, StringFormat={}{0:P2}}"/>
+                            <TextBlock Grid.Column="4" Text="{Binding Size}"/>
+                            <TextBlock Grid.Column="5" Text="{Binding TotalItems}"/>
+                            <TextBlock Grid.Column="6" Text="{Binding TotalFiles}"/>
+                            <TextBlock Grid.Column="7" Text="{Binding TotalSubdirs}"/>
+                            <TextBlock Grid.Column="8" Text="{Binding LastModified, StringFormat={}{0:G}}"/>
+                            <TextBlock Grid.Column="9" Text="{Binding Attributes}"/>
+                        </Grid>
+                    </HierarchicalDataTemplate>
+                </TreeView.Resources>
+            </TreeView>
         </Grid>
     </Grid>
 </Window>

--- a/windirstat_s3/MainWindow.xaml.cs
+++ b/windirstat_s3/MainWindow.xaml.cs
@@ -24,12 +24,6 @@ public partial class MainWindow : Window, INotifyPropertyChanged
     private Stopwatch? _stopwatch;
 
     public ObservableCollection<DirectoryNodeViewModel> RootNodes { get; } = new();
-    private ObservableCollection<DirectoryNodeViewModel> _selectedNodeChildren = new();
-    public ObservableCollection<DirectoryNodeViewModel> SelectedNodeChildren
-    {
-        get => _selectedNodeChildren;
-        set { _selectedNodeChildren = value; OnPropertyChanged(nameof(SelectedNodeChildren)); }
-    }
 
     private double _progressPercent;
     public double ProgressPercent
@@ -102,7 +96,6 @@ public partial class MainWindow : Window, INotifyPropertyChanged
             var rootView = new DirectoryNodeViewModel(_result, _result.Size);
             RootNodes.Clear();
             RootNodes.Add(rootView);
-            SelectedNodeChildren = new ObservableCollection<DirectoryNodeViewModel>(rootView.Children);
         }
         catch (OperationCanceledException)
         {
@@ -160,14 +153,6 @@ public partial class MainWindow : Window, INotifyPropertyChanged
         catch (Exception ex)
         {
             MessageBox.Show(ex.Message, "Erro", MessageBoxButton.OK, MessageBoxImage.Error);
-        }
-    }
-
-    private void ResultTree_SelectedItemChanged(object sender, RoutedPropertyChangedEventArgs<object> e)
-    {
-        if (ResultTree.SelectedItem is DirectoryNodeViewModel node)
-        {
-            SelectedNodeChildren = new ObservableCollection<DirectoryNodeViewModel>(node.Children);
         }
     }
 

--- a/windirstat_s3/ViewModels/DirectoryNodeViewModel.cs
+++ b/windirstat_s3/ViewModels/DirectoryNodeViewModel.cs
@@ -8,6 +8,7 @@ namespace windirstat_s3.ViewModels;
 public class DirectoryNodeViewModel
 {
     private readonly long _totalSize;
+    private readonly long _parentSize;
 
     public string Name { get; }
     public long Size { get; }
@@ -16,9 +17,10 @@ public class DirectoryNodeViewModel
     public DateTime LastModified { get; }
     public ObservableCollection<DirectoryNodeViewModel> Children { get; } = new();
 
-    public DirectoryNodeViewModel(FolderNode node, long totalSize)
+    public DirectoryNodeViewModel(FolderNode node, long totalSize, long parentSize = 0)
     {
         _totalSize = totalSize;
+        _parentSize = parentSize;
         Name = node.Name;
         Size = node.Size;
         OwnSize = node.OwnSize;
@@ -26,7 +28,7 @@ public class DirectoryNodeViewModel
         LastModified = node.LastModified;
         foreach (var child in node.Children.Values.OrderByDescending(c => c.Size))
         {
-            Children.Add(new DirectoryNodeViewModel(child, totalSize));
+            Children.Add(new DirectoryNodeViewModel(child, totalSize, node.Size));
         }
     }
 
@@ -36,4 +38,8 @@ public class DirectoryNodeViewModel
     public int TotalSubdirs => Children.Count;
     public long TotalItems => TotalFiles + TotalSubdirs;
     public string Attributes => string.Empty;
+
+    public double PercentOfParent => _parentSize == 0 ? 1 : (double)Size / _parentSize;
+
+    public string IconGlyph => Children.Any() ? "\uE8B7" : "\uE8A5"; // Folder or Document
 }


### PR DESCRIPTION
## Summary
- Combine directory tree and details into one tree view with column headers
- Show folder usage via progress bar and Windows-style icons
- Remove separate details grid and related code

## Testing
- `dotnet build windirstat_s3/windirstat_s3.sln` *(fails: The imported project "/usr/lib/dotnet/sdk/8.0.118/Sdks/Microsoft.NET.Sdk.WindowsDesktop/targets/Microsoft.NET.Sdk.WindowsDesktop.targets" was not found)*

------
https://chatgpt.com/codex/tasks/task_b_6894b0cc4aa48327a997770a9623a396