### PR TITLE
Include Windirstat.Core project in solution

### DIFF
--- a/windirstat_s3/windirstat_s3.csproj
+++ b/windirstat_s3/windirstat_s3.csproj
@@ -13,7 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\\Windirstat.Core\\Windirstat.Core.csproj" />
+    <ProjectReference Include="../Windirstat.Core/Windirstat.Core.csproj" />
   </ItemGroup>
 
 </Project>

--- a/windirstat_s3/windirstat_s3.sln
+++ b/windirstat_s3/windirstat_s3.sln
@@ -5,12 +5,18 @@ VisualStudioVersion = 17.11.35327.3
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "windirstat_s3", "windirstat_s3.csproj", "{A913EAD1-C01B-46DE-8B5E-9814D8EDC19F}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Windirstat.Core", "..\Windirstat.Core\Windirstat.Core.csproj", "{857DC676-F200-4CE0-B752-1E62E76AD8C0}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{857DC676-F200-4CE0-B752-1E62E76AD8C0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{857DC676-F200-4CE0-B752-1E62E76AD8C0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{857DC676-F200-4CE0-B752-1E62E76AD8C0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{857DC676-F200-4CE0-B752-1E62E76AD8C0}.Release|Any CPU.Build.0 = Release|Any CPU
 		{A913EAD1-C01B-46DE-8B5E-9814D8EDC19F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{A913EAD1-C01B-46DE-8B5E-9814D8EDC19F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A913EAD1-C01B-46DE-8B5E-9814D8EDC19F}.Release|Any CPU.ActiveCfg = Release|Any CPU


### PR DESCRIPTION
## Summary
- Add Windirstat.Core to solution file with build configurations
- Use cross-platform path for Windirstat.Core project reference

## Testing
- `dotnet restore windirstat_s3.sln`
- `dotnet build windirstat_s3.sln` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_b_6894b3da43e88327ac2888a9f2e89918