### PR TITLE
Fix read-only PercentOfParent binding in ProgressBar

### DIFF
--- a/windirstat_s3/MainWindow.xaml
+++ b/windirstat_s3/MainWindow.xaml
@@ -71,7 +71,7 @@
                                 <ColumnDefinition Width="150" SharedSizeGroup="colLastChanged"/>
                                 <ColumnDefinition Width="100" SharedSizeGroup="colAttributes"/>
                             </Grid.ColumnDefinitions>
-                            <ProgressBar Grid.Column="0" Minimum="0" Maximum="1" Value="{Binding PercentOfParent}" Margin="0,2,0,2"/>
+                            <ProgressBar Grid.Column="0" Minimum="0" Maximum="1" Value="{Binding PercentOfParent, Mode=OneWay}" Margin="0,2,0,2"/>
                             <StackPanel Grid.Column="1" Orientation="Horizontal">
                                 <TextBlock FontFamily="Segoe MDL2 Assets" Text="{Binding IconGlyph}" Margin="0,0,4,0"/>
                                 <TextBlock Text="{Binding Name}"/>


### PR DESCRIPTION
## Summary
- avoid XamlParseException by binding `ProgressBar.Value` to `PercentOfParent` using `Mode=OneWay`

## Testing
- `dotnet build windirstat_s3/windirstat_s3.csproj` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*
- `dotnet test windirstat_s3/windirstat_s3.csproj` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_b_6894ee296d4c8327bd91d964ed2fe62c