### PR TITLE
Align tree view columns, list files, and move progress bar to footer

### DIFF
--- a/Windirstat.Core/Models/FolderNode.cs
+++ b/Windirstat.Core/Models/FolderNode.cs
@@ -13,8 +13,10 @@ public class FolderNode
     public Dictionary<string, FolderNode> Children { get; } = new();
     public Dictionary<string, ExtensionInfo> Extensions { get; } = new();
 
-    public FolderNode(string name)
+    public bool IsFile { get; }
+    public FolderNode(string name, bool isFile = false)
     {
         Name = name;
+        IsFile = isFile;
     }
 }

--- a/Windirstat.Core/S3Scanner.cs
+++ b/Windirstat.Core/S3Scanner.cs
@@ -126,7 +126,20 @@ public class S3Scanner
 
             UpdateExtension(node, extension, size);
         }
+
         node.OwnSize += size;
+
+        var fileName = parts[^1];
+        var fileNode = new FolderNode(fileName, isFile: true)
+        {
+            Size = size,
+            OwnSize = size,
+            FileCount = 1,
+            LastModified = lastModified
+        };
+        node.Children[fileName] = fileNode;
+
+        UpdateExtension(fileNode, extension, size);
     }
 
     private static void UpdateExtension(FolderNode node, string extension, long size)

--- a/windirstat_s3/Converters/DepthToIndentConverter.cs
+++ b/windirstat_s3/Converters/DepthToIndentConverter.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Globalization;
+using System.Windows;
+using System.Windows.Data;
+
+namespace windirstat_s3.Converters;
+
+public class DepthToIndentConverter : IValueConverter
+{
+    public double IndentSize { get; set; } = 19;
+
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        if (value is int depth)
+        {
+            return new Thickness(depth * IndentSize, 0, 0, 0);
+        }
+        return new Thickness(0);
+    }
+
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/windirstat_s3/MainWindow.xaml
+++ b/windirstat_s3/MainWindow.xaml
@@ -2,11 +2,16 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:viewModels="clr-namespace:windirstat_s3.ViewModels"
+        xmlns:converters="clr-namespace:windirstat_s3.Converters"
         Title="WinDirStat S3" Height="600" Width="900">
+    <Window.Resources>
+        <converters:DepthToIndentConverter x:Key="DepthToIndentConverter"/>
+    </Window.Resources>
     <Grid Margin="10">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
 
         <StackPanel Orientation="Horizontal" Margin="0,0,0,10">
@@ -17,8 +22,6 @@
             <TextBlock Text="Ignorar Prefixos:" Margin="10,0,0,0" VerticalAlignment="Center"/>
             <TextBox x:Name="IgnorePrefixesTextBox" Width="150" Margin="5,0,0,0" ToolTip="Separe por vírgulas"/>
             <Button Content="Scan" Margin="10,0,0,0" Click="ScanButton_Click"/>
-            <ProgressBar Width="100" Height="20" Margin="10,0,0,0" Minimum="0" Maximum="100" Value="{Binding ProgressPercent}"/>
-            <TextBlock Text="{Binding ScanTime}" Margin="10,0,0,0" VerticalAlignment="Center"/>
             <Button x:Name="CancelButton" Content="Cancelar" Margin="10,0,0,0" Click="CancelButton_Click" IsEnabled="False"/>
             <Button Content="Export CSV" Margin="10,0,0,0" Click="ExportCsvButton_Click"/>
             <Button Content="Export JSON" Margin="5,0,0,0" Click="ExportJsonButton_Click"/>
@@ -30,7 +33,7 @@
                 <RowDefinition Height="*"/>
             </Grid.RowDefinitions>
 
-            <Grid Grid.Row="0" Margin="19,0,0,0">
+            <Grid Grid.Row="0">
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="200" SharedSizeGroup="colName"/>
                     <ColumnDefinition Width="100" SharedSizeGroup="colProgress"/>
@@ -54,6 +57,12 @@
             </Grid>
 
             <TreeView x:Name="ResultTree" Grid.Row="1" ItemsSource="{Binding RootNodes}">
+                <TreeView.ItemContainerStyle>
+                    <Style TargetType="TreeViewItem">
+                        <Setter Property="Padding" Value="0"/>
+                        <Setter Property="Margin" Value="0"/>
+                    </Style>
+                </TreeView.ItemContainerStyle>
                 <TreeView.Resources>
                     <HierarchicalDataTemplate DataType="{x:Type viewModels:DirectoryNodeViewModel}" ItemsSource="{Binding Children}">
                         <Grid>
@@ -68,7 +77,7 @@
                                 <ColumnDefinition Width="150" SharedSizeGroup="colLastChanged"/>
                                 <ColumnDefinition Width="100" SharedSizeGroup="colAttributes"/>
                             </Grid.ColumnDefinitions>
-                            <StackPanel Grid.Column="0" Orientation="Horizontal">
+                            <StackPanel Grid.Column="0" Orientation="Horizontal" Margin="{Binding Depth, Converter={StaticResource DepthToIndentConverter}}">
                                 <TextBlock FontFamily="Segoe MDL2 Assets" Text="{Binding IconGlyph}" Margin="0,0,4,0"/>
                                 <TextBlock Text="{Binding Name}"/>
                             </StackPanel>
@@ -85,5 +94,10 @@
                 </TreeView.Resources>
             </TreeView>
         </Grid>
+
+        <StackPanel Grid.Row="2" Orientation="Horizontal" Margin="0,10,0,0">
+            <ProgressBar Width="100" Height="20" Minimum="0" Maximum="100" Value="{Binding ProgressPercent}"/>
+            <TextBlock Text="{Binding ScanTime}" Margin="10,0,0,0" VerticalAlignment="Center"/>
+        </StackPanel>
     </Grid>
 </Window>

--- a/windirstat_s3/ViewModels/DirectoryNodeViewModel.cs
+++ b/windirstat_s3/ViewModels/DirectoryNodeViewModel.cs
@@ -18,18 +18,23 @@ public class DirectoryNodeViewModel
     public DateTime LastModified { get; }
     public ObservableCollection<DirectoryNodeViewModel> Children { get; } = new();
 
-    public DirectoryNodeViewModel(FolderNode node, long totalSize, long parentSize = 0)
+    public bool IsFile { get; }
+    public int Depth { get; }
+
+    public DirectoryNodeViewModel(FolderNode node, long totalSize, long parentSize = 0, int depth = 0)
     {
         _totalSize = totalSize;
         _parentSize = parentSize;
+        Depth = depth;
         Name = node.Name;
         Size = node.Size;
         OwnSize = node.OwnSize;
         FileCount = node.FileCount;
         LastModified = node.LastModified;
+        IsFile = node.IsFile;
         foreach (var child in node.Children.Values.OrderByDescending(c => c.Size))
         {
-            Children.Add(new DirectoryNodeViewModel(child, totalSize, node.Size));
+            Children.Add(new DirectoryNodeViewModel(child, totalSize, node.Size, depth + 1));
         }
     }
 
@@ -42,7 +47,7 @@ public class DirectoryNodeViewModel
 
     public double PercentOfParent => _parentSize == 0 ? 1 : (double)Size / _parentSize;
 
-    public string IconGlyph => Children.Any() ? "\uE8B7" : "\uE8A5"; // Folder or Document
+    public string IconGlyph => IsFile ? "\uE8A5" : "\uE8B7"; // Document or Folder
 
     private static string FormatBytes(long bytes)
     {


### PR DESCRIPTION
## Summary
- add file nodes and `IsFile` flag so S3 scan results include individual file names
- align tree view columns by removing default indentation and applying manual depth-based spacing
- relocate scan progress bar to window footer

## Testing
- `dotnet build Windirstat.Core/Windirstat.Core.csproj`
- `dotnet build windirstat_s3/windirstat_s3.sln` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets was not found)*

------
https://chatgpt.com/codex/tasks/task_b_68963f5eef408327b22fb20f5aca15c3